### PR TITLE
deploy/repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "rrcm"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rrcm"
-version = "0.3.4"
+version = "0.4.0"
 edition = "2021"
 license-file = "LICENSE"
 description = "Rust RC file Management commands"

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ RUN cargo binstall -y \
     cargo-nextest \
     cargo-make \
     cargo-edit \
-    cargo-outdated
+    cargo-outdated \
+    cargo-readme
 
 ENTRYPOINT ["cargo", "make"]
 CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Workflow Status](https://github.com/mizuki0629/rrcm/workflows/Test/badge.svg)](https://github.com/mizuki0629/rrcm/actions?query=workflow%3A%22Test%22)
 [![codecov](https://codecov.io/gh/mizuki0629/rrcm/branch/master/graph/badge.svg?token=IVPHQ5UQIL)](https://codecov.io/gh/mizuki0629/rrcm)
 
+A cross-platform compatible tool for deploying multiple dotfiles repositories.
+
 ## Introduction
 - Deploy configuration files and directories using symbolic links.
 - Configuration files and directories are managed in a git repository.
@@ -32,10 +34,21 @@ configuration file path:
 The repository is defined in the config.yaml file.
 ```yaml
 repos:
-# your dotfiles repository
-# you can define multiple repositories
-  example1: 'git@github:example/example1'
-  example2: 'git@github:example/example2'
+  - name: dotilfes
+    url: 'git@github:example/example1'
+    deploy:
+      home:
+        windows: "%USERPROFILE%"
+        mac: "${HOME}"
+        linux: "${HOME}"
+      config:
+        windows: "%FOLDERID_RoamingAppData%"
+        mac: "${XDG_CONFIG_HOME}"
+        linux: "${XDG_CONFIG_HOME}"
+      config_local:
+        windows: "%FOLDERID_LocalAppData%"
+        mac: "${XDG_CONFIG_HOME}"
+        linux: "${XDG_CONFIG_HOME}"
 ```
 the repository is a directory that contains the dotfiles.
 Directory structure example:
@@ -63,23 +76,6 @@ Under the deployment target, the file or directory is deployed by symbolic link.
 **Windows needs to be run as administrator.**
 
 ### Deployment target
-The deployment target is defined in the config.yaml file.
-```yaml
-deploy:
-  home:
-    windows: "%USERPROFILE%"
-    mac: "${HOME}"
-    linux: "${HOME}"
-  config:
-    windows: "%FOLDERID_RoamingAppData%"
-    mac: "${XDG_CONFIG_HOME}"
-    linux: "${XDG_CONFIG_HOME}"
-  config_local:
-    windows: "%FOLDERID_LocalAppData%"
-    mac: "${XDG_CONFIG_HOME}"
-    linux: "${XDG_CONFIG_HOME}"
-```
-
 Environment variables can be used in the deployment target.
 Format
 - Unix: ${ENVIRONMENT_VARIABLE_NAME}

--- a/README.tpl
+++ b/README.tpl
@@ -3,4 +3,6 @@
 {{badges}}
 [![codecov](https://codecov.io/gh/mizuki0629/rrcm/branch/master/graph/badge.svg?token=IVPHQ5UQIL)](https://codecov.io/gh/mizuki0629/rrcm)
 
+A cross-platform compatible tool for deploying multiple dotfiles repositories.
+
 {{readme}}

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,10 +27,21 @@
 //! The repository is defined in the config.yaml file.
 //! ```yaml
 //! repos:
-//! # your dotfiles repository
-//! # you can define multiple repositories
-//!   example1: 'git@github:example/example1'
-//!   example2: 'git@github:example/example2'
+//!   - name: dotilfes
+//!     url: 'git@github:example/example1'
+//!     deploy:
+//!       home:
+//!         windows: "%USERPROFILE%"
+//!         mac: "${HOME}"
+//!         linux: "${HOME}"
+//!       config:
+//!         windows: "%FOLDERID_RoamingAppData%"
+//!         mac: "${XDG_CONFIG_HOME}"
+//!         linux: "${XDG_CONFIG_HOME}"
+//!       config_local:
+//!         windows: "%FOLDERID_LocalAppData%"
+//!         mac: "${XDG_CONFIG_HOME}"
+//!         linux: "${XDG_CONFIG_HOME}"
 //! ```
 //! the repository is a directory that contains the dotfiles.
 //! Directory structure example:
@@ -58,23 +69,6 @@
 //! **Windows needs to be run as administrator.**
 //!
 //! ### Deployment target
-//! The deployment target is defined in the config.yaml file.
-//! ```yaml
-//! deploy:
-//!   home:
-//!     windows: "%USERPROFILE%"
-//!     mac: "${HOME}"
-//!     linux: "${HOME}"
-//!   config:
-//!     windows: "%FOLDERID_RoamingAppData%"
-//!     mac: "${XDG_CONFIG_HOME}"
-//!     linux: "${XDG_CONFIG_HOME}"
-//!   config_local:
-//!     windows: "%FOLDERID_LocalAppData%"
-//!     mac: "${XDG_CONFIG_HOME}"
-//!     linux: "${XDG_CONFIG_HOME}"
-//! ```
-//!
 //! Environment variables can be used in the deployment target.
 //! Format
 //! - Unix: ${ENVIRONMENT_VARIABLE_NAME}

--- a/tests/init_url_config.yaml
+++ b/tests/init_url_config.yaml
@@ -3,21 +3,22 @@ dotfiles:
   windows: "%USERPROFILE%\\dotfiles"
   mac: "${HOME}/.dotfiles"
   linux: "${HOME}/.dotfiles"
-deploy:
-  home:
-    windows: "%USERPROFILE%"
-    mac: "${HOME}"
-    linux: "${HOME}"
-  config:
-    windows: "%FOLDERID_RoamingAppData%"
-    mac: "${XDG_CONFIG_HOME}"
-    linux: "${XDG_CONFIG_HOME}"
-  config_local:
-    windows: "%FOLDERID_LocalAppData%"
-    mac: "${XDG_CONFIG_HOME}"
-    linux: "${XDG_CONFIG_HOME}"
-  config_unix:
-    mac: "${XDG_CONFIG_HOME}"
-    linux: "${XDG_CONFIG_HOME}"
 repos:
-  dotfiles: 'https://github.com/mizuki0629/rrcm-test.git'
+  - name: dotilfes
+    url: 'https://github.com/mizuki0629/rrcm-test.git'
+    deploy:
+      home:
+        windows: "%USERPROFILE%"
+        mac: "${HOME}"
+        linux: "${HOME}"
+      config:
+        windows: "%FOLDERID_RoamingAppData%"
+        mac: "${XDG_CONFIG_HOME}"
+        linux: "${XDG_CONFIG_HOME}"
+      config_local:
+        windows: "%FOLDERID_LocalAppData%"
+        mac: "${XDG_CONFIG_HOME}"
+        linux: "${XDG_CONFIG_HOME}"
+      config_unix:
+        mac: "${XDG_CONFIG_HOME}"
+        linux: "${XDG_CONFIG_HOME}"


### PR DESCRIPTION
# deploy/repository

## Summary of Changes:
- Transition from a centralized deployment setup to repository-specific configurations.
- **Breaking Change**: Significant modifications in the `config.yaml` structure.

## Details:
The `config.yaml` structure has transitioned from a centralized deployment setup (`deploy` and `repos`) to repository-specific configurations.

**Old Format:**
```yaml
dotfiles:
  windows: "%USERPROFILE%\\dotfiles"
  mac: "${HOME}/.dotfiles"
  linux: "${HOME}/.dotfiles"
deploy:
  home:
    windows: "%USERPROFILE%"
    mac: "${HOME}"
    linux: "${HOME}"
  config:
    windows: "%FOLDERID_RoamingAppData%"
    mac: "${XDG_CONFIG_HOME}"
    linux: "${XDG_CONFIG_HOME}"
repos:
  dotfiles: 'https://github.com/mizuki0629/rrcm-test.git'
```
**New Format:**
```yaml
dotfiles:
  windows: "%USERPROFILE%\\dotfiles"
  mac: "${HOME}/.dotfiles"
  linux: "${HOME}/.dotfiles"
repos:
  - name: dotfiles
    url: 'https://github.com/mizuki0629/rrcm-test.git'
    deploy:
      home:
        windows: "%USERPROFILE%"
        mac: "${HOME}"
        linux: "${HOME}"
      config:
        windows: "%FOLDERID_RoamingAppData%"
        mac: "${XDG_CONFIG_HOME}"
        linux: "${XDG_CONFIG_HOME}"
```